### PR TITLE
Auto-install Node 18 in setup script

### DIFF
--- a/quick-setup.sh
+++ b/quick-setup.sh
@@ -3,15 +3,34 @@
 # Checks for Node.js and npm, then installs dependencies using npm ci.
 set -e
 
-# Ensure Node.js is installed
+# Ensure Node.js is installed, install automatically if missing
 if ! command -v node >/dev/null 2>&1; then
-    echo "Error: Node.js is not installed. Please install Node.js 16 or newer."
-    exit 1
+    echo "Node.js not found. Installing Node.js 18..."
+
+    OS_NAME="$(uname)"
+    case "$OS_NAME" in
+        Linux)
+            curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && \
+            sudo apt-get install -y nodejs
+            ;;
+        Darwin)
+            if command -v brew >/dev/null 2>&1; then
+                brew install node@18
+            else
+                echo "Homebrew not found. Please install Node.js 18 manually." >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Unsupported OS: $OS_NAME. Please install Node.js 18 manually." >&2
+            exit 1
+            ;;
+    esac
 fi
 
 # Ensure npm is installed
 if ! command -v npm >/dev/null 2>&1; then
-    echo "Error: npm is not installed. Please install Node.js which includes npm."
+    echo "Error: npm is not installed. Please ensure Node.js 18 is installed correctly." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- auto-install Node.js 18 if not present
- keep non-interactive install logic for Linux and macOS

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6843274a25d483228876d74edd75695f